### PR TITLE
Fix failure when deploying a fresh install on a new host

### DIFF
--- a/container/kvm-server-manage
+++ b/container/kvm-server-manage
@@ -56,7 +56,7 @@ if [[ "$COMMAND" = "enable" || "$COMMAND" = "restart" ]]; then
    fi
 
    # (Re)Start the kvm server container
-   if [[ "$CONTAINER_STATE" = "inactive" || "$COMMAND" = "restart" ]]; then
+   if [[ "$CONTAINER_STATE" != "active" || "$COMMAND" = "restart" ]]; then
       echo -e "${Y}${SYM} ${N}Starting KVM Container"
       systemctl daemon-reload
       systemctl enable kvm-server-container.service

--- a/container/kvm-server-manage
+++ b/container/kvm-server-manage
@@ -66,6 +66,16 @@ if [[ "$COMMAND" = "enable" || "$COMMAND" = "restart" ]]; then
    fi
 
    # Enable modular libvirt daemons on the host
+   for drv in log lock
+   do
+      systemctl enable container-virt${drv}d.service
+      systemctl enable virt${drv}d{,-admin}.socket
+      systemctl restart virt${drv}d{,-admin}.socket
+      systemctl restart container-virt${drv}d.service && \
+         echo -e "${G}${SYM} ${N}Started container-virt${drv}d.service" || \
+         echo -e "${R}${SYM} ${N}Failed to start container-virt${drv}d.service"
+   done
+
    for drv in qemu network nodedev nwfilter proxy secret storage
    do
       systemctl unmask container-virt${drv}d.service
@@ -73,16 +83,6 @@ if [[ "$COMMAND" = "enable" || "$COMMAND" = "restart" ]]; then
       systemctl enable container-virt${drv}d.service
       systemctl enable virt${drv}d{,-ro,-admin}.socket
       systemctl restart virt${drv}d{,-ro,-admin}.socket
-      systemctl restart container-virt${drv}d.service && \
-         echo -e "${G}${SYM} ${N}Started container-virt${drv}d.service" || \
-         echo -e "${R}${SYM} ${N}Failed to start container-virt${drv}d.service"
-   done
-
-   for drv in log lock
-   do
-      systemctl enable container-virt${drv}d.service
-      systemctl enable virt${drv}d{,-admin}.socket
-      systemctl restart virt${drv}d{,-admin}.socket
       systemctl restart container-virt${drv}d.service && \
          echo -e "${G}${SYM} ${N}Started container-virt${drv}d.service" || \
          echo -e "${R}${SYM} ${N}Failed to start container-virt${drv}d.service"

--- a/container/label-install
+++ b/container/label-install
@@ -2,8 +2,6 @@
 # This is the install script for kvm when run in a privileged
 # container.
 
-cd /
-PATH="/usr/bin:/usr/sbin"
 CONTAINER=kvm-server
 # ETC
 MAINCONF=${CONTAINER}.conf
@@ -20,6 +18,15 @@ is_read_only() {
 
 # Install/update scripts on the host 
 BIN_INSTALL_PATH=$(is_read_only && echo "/host/usr/local/bin" || echo "/host/usr/bin")
+SYSTEMD_INSTALL_PATH=$(is_read_only && echo "/host/usr/local/lib/systemd/system" || echo "/host/usr/lib/systemd/system")
+
+install_common() {
+   mkdir -p /host/etc/libvirt
+   mkdir -p /host/var/lib/libvirt/images
+   mkdir -p /host/etc/libvirt/qemu/networks
+   mkdir -p ${SYSTEMD_INSTALL_PATH}
+}
+
 install_bin() {
    SCRIPT=$1
    cp -a /container/${SCRIPT} ${BIN_INSTALL_PATH}/
@@ -37,18 +44,13 @@ install_config() {
    fi
 }
 
-SYSTEMD_INSTALL_PATH=$(is_read_only && echo "/host/usr/local/lib/systemd/system" || echo "/host/usr/lib/systemd/system")
 install_units() {
-   # Create systemd directory if not present
-   if [ ! -e ${SYSTEMD_INSTALL_PATH} ]; then
-      mkdir -p ${SYSTEMD_INSTALL_PATH}
-   fi
    cp -a /container/systemd/* ${SYSTEMD_INSTALL_PATH}/
 }
 
 ## MAIN
-echo "LABEL INSTALL"
-mkdir -p /host/etc/libvirt/qemu/networks
+echo "Running Install Label"
+install_common
 install_config ${MAINCONF}
 install_config ${NETCONF}
 install_config ${QEMUCONF}
@@ -66,6 +68,3 @@ if [ "${INSTALL_IMAGE}" != "${IMAGE}" ]; then
    sed -i "s|^IMAGE=.*$|DEFAULT_IMAGE=${IMAGE}\nIMAGE=${INSTALL_IMAGE}|" host/etc/${MAINCONF}
 fi
 
-# FIXME: Image location not present on host, is there a better way to do this?
-mkdir -p /host/var/lib/libvirt/images
-cd /host/usr/local/bin/

--- a/container/label-uninstall
+++ b/container/label-uninstall
@@ -4,8 +4,6 @@
 # container.
 
 CONTAINER=kvm-server
-cd /
-PATH="/usr/bin:/usr/sbin"
 
 # Check for read only root filesystem
 is_read_only() {
@@ -26,9 +24,6 @@ fi
 
 BIN_INSTALL_PATH=$(is_read_only && echo "/host/usr/local/bin" || echo "/host/usr/bin")
 SYSTEMD_INSTALL_PATH=$(is_read_only && echo "/host/usr/local/lib/systemd/system" || echo "/host/usr/lib/systemd/system")
-
-# First disable the container and services
-${BIN_INSTALL_PATH}/kvm-server-manage disable
 
 # removing installed files
 echo "LABEL UNINSTALL: Removing all files"
@@ -59,3 +54,7 @@ delete_file ${SYSTEMD_INSTALL_PATH} libvirtd-admin.socket
 delete_file ${SYSTEMD_INSTALL_PATH} libvirtd-tls.socket
 delete_file ${SYSTEMD_INSTALL_PATH} libvirtd-tcp.socket
 delete_file ${SYSTEMD_INSTALL_PATH} kvm-server-container.service
+
+# Remove installed libvirt configs
+/usr/bin/rm -rf /host/etc/libvirt
+

--- a/container/systemd/kvm-server-container.service
+++ b/container/systemd/kvm-server-container.service
@@ -26,9 +26,9 @@ Environment=CONTAINER_NAME="kvm-server"
 EnvironmentFile=-/etc/sysconfig/kvm-server-container
 EnvironmentFile=-/etc/kvm-server.conf
 ExecStartPre=/bin/rm -f %t/%n.pid %t/%n.ctr-id
-ExecStartPre=mkdir -p /run/libvirt
+ExecStartPre=/usr/bin/mkdir -p /run/libvirt
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n.pid --cidfile %t/%n.ctr-id --cgroups=no-conmon --sdnotify=conmon --init --detach --replace --rm --net=host --privileged --cgroupns=host -e IMAGE=${IMAGE} -v /:/host -v /run/libvirt:/run/libvirt -v /etc/libvirt:/etc/libvirt -v /var/lib/libvirt/images:/var/lib/libvirt/images --name ${CONTAINER_NAME} ${IMAGE} /usr/bin/sleep infinity
-ExecStop=-/usr/bin/podman exec --detach --privileged ${CONTAINER_NAME} virsh stop --all
+ExecStop=-+virsh -c qemu:///system stop --all
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n.ctr-id
 KillMode=control-group

--- a/container/systemd/kvm-server-container.service
+++ b/container/systemd/kvm-server-container.service
@@ -26,7 +26,8 @@ Environment=CONTAINER_NAME="kvm-server"
 EnvironmentFile=-/etc/sysconfig/kvm-server-container
 EnvironmentFile=-/etc/kvm-server.conf
 ExecStartPre=/bin/rm -f %t/%n.pid %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n.pid --cidfile %t/%n.ctr-id --cgroups=no-conmon --sdnotify=conmon --init --detach --replace --rm --net=host --privileged --cgroupns=host -e IMAGE=${IMAGE} -v /:/host -v /run/libvirt:/run/libvirt -v /etc/libvirt:/etc/libvirt -v /etc/libvirt/qemu:/etc/libvirt/qemu -v /var/lib/libvirt/images:/var/lib/libvirt/images -v /lib/modules:/lib/modules:ro -v /etc/machine-id:/etc/machine-id:ro --name ${CONTAINER_NAME} ${IMAGE} /usr/bin/sleep infinity
+ExecStartPre=mkdir -p /run/libvirt
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n.pid --cidfile %t/%n.ctr-id --cgroups=no-conmon --sdnotify=conmon --init --detach --replace --rm --net=host --privileged --cgroupns=host -e IMAGE=${IMAGE} -v /:/host -v /run/libvirt:/run/libvirt -v /etc/libvirt:/etc/libvirt -v /var/lib/libvirt/images:/var/lib/libvirt/images --name ${CONTAINER_NAME} ${IMAGE} /usr/bin/sleep infinity
 ExecStop=-/usr/bin/podman exec --detach --privileged ${CONTAINER_NAME} virsh stop --all
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n.ctr-id


### PR DESCRIPTION
- Fixes #6
- Caused by /run/libvirt not being present before starting the container
- Ensure directories are installed/uninstalled correctly
- Change the order we start the libvirt services
